### PR TITLE
Fix find usage for template definitions.

### DIFF
--- a/src/com/google/bamboo/soy/elements/TemplateDefinitionElement.java
+++ b/src/com/google/bamboo/soy/elements/TemplateDefinitionElement.java
@@ -15,9 +15,11 @@
 package com.google.bamboo.soy.elements;
 
 import com.google.bamboo.soy.stubs.TemplateDefinitionStub;
+import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.StubBasedPsiElement;
 
 /** The PSI element that represents the template name in a template block definition. */
-public interface TemplateDefinitionElement extends StubBasedPsiElement<TemplateDefinitionStub> {
+public interface TemplateDefinitionElement
+    extends StubBasedPsiElement<TemplateDefinitionStub>, PsiNamedElement {
   String getName();
 }

--- a/src/com/google/bamboo/soy/elements/TemplateDefinitionMixin.java
+++ b/src/com/google/bamboo/soy/elements/TemplateDefinitionMixin.java
@@ -16,8 +16,11 @@ package com.google.bamboo.soy.elements;
 
 import com.google.bamboo.soy.stubs.TemplateDefinitionStub;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
 
 public class TemplateDefinitionMixin extends SoyStubBasedPsiElementBase<TemplateDefinitionStub>
     implements TemplateDefinitionElement {
@@ -35,10 +38,11 @@ public class TemplateDefinitionMixin extends SoyStubBasedPsiElementBase<Template
 
   @Override
   public String getName() {
-    try {
-      return getStub().name;
-    } catch (NullPointerException e) {
-      return getText();
-    }
+    return getStub() != null ? getStub().name : getText();
+  }
+
+  @Override
+  public PsiElement setName(@NotNull String s) throws IncorrectOperationException {
+    return null;
   }
 }

--- a/src/com/google/bamboo/soy/elements/references/TemplateDefinitionReference.java
+++ b/src/com/google/bamboo/soy/elements/references/TemplateDefinitionReference.java
@@ -49,8 +49,9 @@ public class TemplateDefinitionReference extends PsiReferenceBase<PsiElement>
   public boolean isReferenceTo(PsiElement element) {
     ResolveResult[] results = multiResolve(false);
     for (ResolveResult result : results) {
-      if (this.getElement().getManager().areElementsEquivalent(result.getElement(), element))
+      if (this.getElement().getManager().areElementsEquivalent(result.getElement(), element)) {
         return true;
+      }
     }
     return false;
   }

--- a/src/com/google/bamboo/soy/stubs/TemplateDefinitionStub.java
+++ b/src/com/google/bamboo/soy/stubs/TemplateDefinitionStub.java
@@ -21,6 +21,8 @@ import com.google.bamboo.soy.parser.impl.SoyTemplateDefinitionIdentifierImpl;
 import com.google.bamboo.soy.stubs.index.TemplateDefinitionIndex;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.IndexSink;
+import com.intellij.psi.stubs.NamedStub;
+import com.intellij.psi.stubs.NamedStubBase;
 import com.intellij.psi.stubs.StubBase;
 import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
@@ -29,13 +31,13 @@ import com.intellij.util.io.StringRef;
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
 
-public class TemplateDefinitionStub extends StubBase<SoyTemplateDefinitionIdentifier> {
+public class TemplateDefinitionStub extends NamedStubBase<SoyTemplateDefinitionIdentifier> {
   static final Type TYPE = new Type();
   public final String name;
   public final String fullyQualifiedName;
 
   TemplateDefinitionStub(StubElement parent, String name, String fullyQualifiedName) {
-    super(parent, TYPE);
+    super(parent, TYPE, name);
     this.name = name;
     this.fullyQualifiedName = fullyQualifiedName;
   }


### PR DESCRIPTION
Elements that are being referenced to need to implement PsiNamedElement.