### PR TITLE
Add test for variables in scope completion.

### DIFF
--- a/src/com/google/bamboo/soy/ParamUtils.java
+++ b/src/com/google/bamboo/soy/ParamUtils.java
@@ -80,7 +80,7 @@ public class ParamUtils {
           PsiElement typeExpression = paramDefinition.getTypeExpression();
           params.add(
               new Variable(
-                  identifier.getText(),
+                  identifier.getName(),
                   typeExpression == null ? "" : typeExpression.getText(),
                   identifier));
         }
@@ -93,7 +93,7 @@ public class ParamUtils {
     PsiElement templateBlock = getParentTemplateBlock(element);
     return PsiTreeUtil.findChildrenOfType(templateBlock, SoyParamDefinitionIdentifier.class)
         .stream()
-        .map(id -> new Variable(id.getText(), "", id))
+        .map(id -> new Variable(id.getName(), "", id))
         .collect(Collectors.toList());
   }
 
@@ -102,7 +102,7 @@ public class ParamUtils {
     return PsiTreeUtil.findChildrenOfType(
             templateBlock, com.google.bamboo.soy.parser.SoyVariableDefinitionIdentifier.class)
         .stream()
-        .map(id -> new Variable(id.getText(), "", id))
+        .map(id -> new Variable(id.getName(), "", id))
         .collect(Collectors.toList());
   }
 

--- a/src/com/google/test/soy/completion/SoyCompletionTest.java
+++ b/src/com/google/test/soy/completion/SoyCompletionTest.java
@@ -15,6 +15,7 @@
 package com.google.test.soy.completion;
 
 import com.google.bamboo.soy.file.SoyFileType;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.test.soy.SoyCodeInsightFixtureTestCase;
 import com.intellij.codeInsight.completion.CompletionType;
@@ -32,7 +33,8 @@ public class SoyCompletionTest extends SoyCodeInsightFixtureTestCase {
     myFixture.configureByText(SoyFileType.INSTANCE, inputText);
     myFixture.complete(CompletionType.BASIC, 1);
     List<String> actualCompletions = myFixture.getLookupElementStrings();
-    assertSameElements(actualCompletions, expectedCompletions);
+    assertSameElements(
+        actualCompletions == null ? ImmutableList.of() : actualCompletions, expectedCompletions);
   }
 
   protected void doTest(String inputText, String expectedText) throws Throwable {
@@ -65,7 +67,8 @@ public class SoyCompletionTest extends SoyCodeInsightFixtureTestCase {
 
   public void testLookupWithPartialAlias() throws Throwable {
     doTest(
-        "{alias outer as inner}{template}{call i<caret>", "{alias outer as inner}{template}{call inner");
+        "{alias outer as inner}{template}{call i<caret>",
+        "{alias outer as inner}{template}{call inner");
     doTest(
         "{alias outer as inner}{template}{call inner.<caret>",
         ImmutableSet.of("inner.space", "inner.spaceship"));
@@ -80,5 +83,11 @@ public class SoyCompletionTest extends SoyCodeInsightFixtureTestCase {
     doTest(
         "{alias outer.space}{template}{call spaceship.e<caret>",
         "{alias outer.space}{template}{call spaceship.e");
+  }
+
+  public void testVariablesInScope() throws Throwable {
+    doTest(
+        "{template .foo}{@param dimension: number}{@inject force: number}{let $multiplier: 10}{<caret>",
+        ImmutableSet.of("$dimension", "$force", "$multiplier"));
   }
 }


### PR DESCRIPTION
+ use `getName` instead of `getText` for named elements in `ParamUtils`.