### PR TITLE
Fragment completion improvements

### DIFF
--- a/src/com/google/bamboo/soy/TemplateNameUtils.java
+++ b/src/com/google/bamboo/soy/TemplateNameUtils.java
@@ -24,11 +24,13 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A helper class for efficient template and namespace lookups.
@@ -129,7 +131,7 @@ public class TemplateNameUtils {
                             .isEmpty())
 
             // Project matches into denormalized key space.
-            .map((key) -> denormalizeIdentifier(aliases, key))
+            .flatMap((key) -> denormalizeIdentifier(aliases, key))
 
             // Ensure that once denormalized the template identifiers still match.
             .filter((key) -> key.startsWith(identifier))
@@ -153,14 +155,18 @@ public class TemplateNameUtils {
     return templateFragments;
   }
 
-  private static String denormalizeIdentifier(Map<String, String> aliases, String identifier) {
+  private static Stream<String> denormalizeIdentifier(
+      Map<String, String> aliases, String identifier) {
+    List<String> identifiers = new ArrayList<>();
+
+    identifiers.add(identifier);
     for (Map.Entry<String, String> entry : aliases.entrySet()) {
       if (identifier.startsWith(entry.getKey())) {
-        return identifier.replace(entry.getKey(), entry.getValue());
+        identifiers.add(identifier.replace(entry.getKey(), entry.getValue()));
       }
     }
 
-    return identifier;
+    return identifiers.stream();
   }
 
   private static String normalizeIdentifier(Map<String, String> aliases, String identifier) {

--- a/src/com/google/bamboo/soy/completion/SoyCompletionContributor.java
+++ b/src/com/google/bamboo/soy/completion/SoyCompletionContributor.java
@@ -246,8 +246,8 @@ public class SoyCompletionContributor extends CompletionContributor {
                     instanceof SoyBeginDelCall;
 
             String prefix = identifier.replaceFirst("IntellijIdeaRulezzz", "");
-            Collection<String> completions =
-                TemplateNameUtils.getTemplateNameIdentifiersFragments(
+            Collection<TemplateNameUtils.Fragment> completions =
+                TemplateNameUtils.getPossibleNextIdentifierFragments(
                     completionParameters.getPosition().getProject(),
                     identifierElement,
                     prefix,
@@ -256,7 +256,13 @@ public class SoyCompletionContributor extends CompletionContributor {
             completionResultSet.addAllElements(
                 completions
                     .stream()
-                    .map(LookupElementBuilder::create)
+                    .map(
+                        (fragment) ->
+                            LookupElementBuilder.create(fragment.text)
+                                .withTypeText(
+                                    fragment.isFinalFragment
+                                        ? (isDelegate ? "Delegate template" : "Template")
+                                        : "Partial namespace"))
                     .collect(Collectors.toList()));
           }
         });
@@ -279,14 +285,18 @@ public class SoyCompletionContributor extends CompletionContributor {
             String identifier = identifierElement == null ? "" : identifierElement.getText();
 
             String prefix = identifier.replaceFirst("IntellijIdeaRulezzz", "");
-            Collection<String> completions =
+            Collection<TemplateNameUtils.Fragment> completions =
                 TemplateNameUtils.getTemplateNamespaceFragments(
                     completionParameters.getPosition().getProject(), prefix);
 
             completionResultSet.addAllElements(
                 completions
                     .stream()
-                    .map(LookupElementBuilder::create)
+                    .map(
+                        (fragment) ->
+                            LookupElementBuilder.create(fragment.text)
+                                .withTypeText(
+                                    fragment.isFinalFragment ? "Namespace" : "Partial namespace"))
                     .collect(Collectors.toList()));
           }
         });


### PR DESCRIPTION
+ Filter out fully qualified identifier completions that come from the same file.

+ Optimize fragment completion by projecting the prefix identifier into the normalized key space instead of the other way around allowing to have a more efficient filter ordering (fast filters eliminating large sets of options first).

+ Display type for the suggested fragment based on whether it's the final fragment or not.

Fixes #29 