### PR TITLE
Find usage for identifiers declared with let.

### DIFF
--- a/src/com/google/bamboo/soy/ParamUtils.java
+++ b/src/com/google/bamboo/soy/ParamUtils.java
@@ -101,7 +101,7 @@ public class ParamUtils {
       assert element instanceof SoyParamDefinitionIdentifier
           || element instanceof SoyVariableDefinitionIdentifier;
 
-      this.name = name;
+      this.name = name.replaceFirst("^\\$", "");
       this.type = type;
       this.isOptional = isOptional;
       this.element = element;

--- a/src/com/google/bamboo/soy/SoyFindUsagesProvider.java
+++ b/src/com/google/bamboo/soy/SoyFindUsagesProvider.java
@@ -31,7 +31,10 @@ public class SoyFindUsagesProvider implements FindUsagesProvider {
   public WordsScanner getWordsScanner() {
     return new DefaultWordsScanner(
         new SoyLexer(),
-        TokenSet.create(SoyTypes.IDENTIFIER, SoyTypes.PARAM_SPECIFICATION_IDENTIFIER),
+        TokenSet.create(
+            SoyTypes.IDENTIFIER,
+            SoyTypes.PARAM_SPECIFICATION_IDENTIFIER,
+            SoyTypes.VARIABLE_DEFINITION_IDENTIFIER),
         TokenSet.create(SoyTypes.COMMENT_BLOCK),
         TokenSet.EMPTY);
   }

--- a/src/com/google/bamboo/soy/elements/VariableDefinitionMixin.java
+++ b/src/com/google/bamboo/soy/elements/VariableDefinitionMixin.java
@@ -16,6 +16,7 @@ package com.google.bamboo.soy.elements;
 
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
@@ -28,11 +29,7 @@ public class VariableDefinitionMixin extends ASTWrapperPsiElement
 
   @Override
   public String getName() {
-    String text = getText();
-    if (text.startsWith("$")) {
-      return text.substring(1);
-    }
-    return text;
+    return getText();
   }
 
   @Override

--- a/src/com/google/bamboo/soy/elements/references/VariableReference.java
+++ b/src/com/google/bamboo/soy/elements/references/VariableReference.java
@@ -46,6 +46,8 @@ public class VariableReference extends PsiReferenceBase<PsiElement> implements P
 
     List<ResolveResult> results = new ArrayList<>();
     for (ParamUtils.Variable definition : definitions) {
+      System.out.println(definition.name + " == " + this.identifier);
+
       if (definition.name.equals(this.identifier)) {
         results.add(new PsiElementResolveResult(definition.element));
       }
@@ -65,6 +67,7 @@ public class VariableReference extends PsiReferenceBase<PsiElement> implements P
     ResolveResult[] results = multiResolve();
     for (ResolveResult result : results) {
       if (this.getElement().getManager().areElementsEquivalent(result.getElement(), element)) {
+        System.out.println("Reference to " + element.getText());
         return true;
       }
     }

--- a/src/com/google/bamboo/soy/elements/references/VariableReference.java
+++ b/src/com/google/bamboo/soy/elements/references/VariableReference.java
@@ -46,8 +46,6 @@ public class VariableReference extends PsiReferenceBase<PsiElement> implements P
 
     List<ResolveResult> results = new ArrayList<>();
     for (ParamUtils.Variable definition : definitions) {
-      System.out.println(definition.name + " == " + this.identifier);
-
       if (definition.name.equals(this.identifier)) {
         results.add(new PsiElementResolveResult(definition.element));
       }
@@ -67,7 +65,6 @@ public class VariableReference extends PsiReferenceBase<PsiElement> implements P
     ResolveResult[] results = multiResolve();
     for (ResolveResult result : results) {
       if (this.getElement().getManager().areElementsEquivalent(result.getElement(), element)) {
-        System.out.println("Reference to " + element.getText());
         return true;
       }
     }


### PR DESCRIPTION
Find usage for identifiers declared with `let` was flakey and this fixes it.

According to the ["Find Usage" documentation,](http://www.jetbrains.org/intellij/sdk/docs/reference_guide/custom_language_support/find_usages.html) it was never allowed to return a substring of the identifier element, but instead one need to either return the complete text or the text of a sub-identifier and then override `getTextOffset` to point to that sub-identifier.

