### PR TITLE
Running closing tag handler _after_ the char is typed.

### DIFF
--- a/src/main/java/com/google/bamboo/soy/insight/typedhandlers/ClosingTagHandler.java
+++ b/src/main/java/com/google/bamboo/soy/insight/typedhandlers/ClosingTagHandler.java
@@ -169,16 +169,13 @@ public class ClosingTagHandler implements TypedActionHandler {
 
   public void execute(@NotNull Editor editor, char charTyped, @NotNull DataContext dataContext) {
     myOriginalHandler.execute(editor, charTyped, dataContext);
-    try {
-      if (isMatchForClosingTag(editor, charTyped)) {
-        int offset = editor.getCaretModel().getOffset();
-        PsiElement el = dataContext.getData(LangDataKeys.PSI_FILE).findElementAt(offset - 1);
-        String closingTag = generateClosingTag(el);
-        if (closingTag != null) {
-          insertClosingTag(editor, offset, closingTag);
-        }
+    if (isMatchForClosingTag(editor, charTyped)) {
+      int offset = editor.getCaretModel().getOffset();
+      PsiElement el = dataContext.getData(LangDataKeys.PSI_FILE).findElementAt(offset - 1);
+      String closingTag = generateClosingTag(el);
+      if (closingTag != null) {
+        insertClosingTag(editor, offset, closingTag);
       }
-    } catch (Exception e) {
     }
   }
 }

--- a/src/main/java/com/google/bamboo/soy/insight/typedhandlers/ClosingTagHandler.java
+++ b/src/main/java/com/google/bamboo/soy/insight/typedhandlers/ClosingTagHandler.java
@@ -33,8 +33,11 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 
-/** Automatically inserts a matching closing tag when "{/" is typed. */
+/**
+ * Automatically inserts a matching closing tag when "{/" is typed.
+ */
 public class ClosingTagHandler implements TypedActionHandler {
+
   private static final ImmutableMap<IElementType, String> blockElementToTagName =
       ImmutableMap.<IElementType, String>builder()
           .put(SoyTypes.DIRECT_CALL_STATEMENT, "call")
@@ -69,15 +72,15 @@ public class ClosingTagHandler implements TypedActionHandler {
 
   private static boolean isMatchForClosingTag(@NotNull Editor editor, char charTyped) {
     return charTyped == '/'
-        && editor.getCaretModel().getOffset() >= 1
-        && editor.getDocument().getCharsSequence().charAt(editor.getCaretModel().getOffset() - 1)
-            == '{';
+        && editor.getCaretModel().getOffset() >= 2
+        && editor.getDocument().getCharsSequence().charAt(editor.getCaretModel().getOffset() - 2)
+        == '{';
   }
 
   private static void insertClosingTag(@NotNull Editor editor, int offset, String tag) {
     Document document = editor.getDocument();
     CharSequence charSequence = document.getImmutableCharSequence();
-    int startPosition = offset - 1;
+    int startPosition = offset - 2;
     // Consume second left brace if present.
     if (offset > 0 && charSequence.charAt(startPosition - 1) == '{') {
       startPosition--;
@@ -165,6 +168,7 @@ public class ClosingTagHandler implements TypedActionHandler {
   }
 
   public void execute(@NotNull Editor editor, char charTyped, @NotNull DataContext dataContext) {
+    myOriginalHandler.execute(editor, charTyped, dataContext);
     try {
       if (isMatchForClosingTag(editor, charTyped)) {
         int offset = editor.getCaretModel().getOffset();
@@ -172,11 +176,9 @@ public class ClosingTagHandler implements TypedActionHandler {
         String closingTag = generateClosingTag(el);
         if (closingTag != null) {
           insertClosingTag(editor, offset, closingTag);
-          return;
         }
       }
     } catch (Exception e) {
     }
-    myOriginalHandler.execute(editor, charTyped, dataContext);
   }
 }

--- a/src/test/java/com/google/bamboo/soy/typing/SoyTypingTest.java
+++ b/src/test/java/com/google/bamboo/soy/typing/SoyTypingTest.java
@@ -93,8 +93,8 @@ public class SoyTypingTest extends SoyCodeInsightFixtureTestCase {
     for (String tag : simpleTags) {
       doTypingTest(
           '/',
-          "{template .bar}{" + tag + "}{<caret> {/template}",
-          "{template .bar}{" + tag + "}{/" + tag + "}<caret> {/template}");
+          "{template .bar}{" + tag + "}{<caret>{/template}",
+          "{template .bar}{" + tag + "}{/" + tag + "}<caret>{/template}");
       doTypingTest(
           '/',
           "{template .bar}{{" + tag + "}} {<caret>} {/template}",


### PR DESCRIPTION
Fixes cases when triggered before "{".