### PR TITLE
Fixes for v.1.2 release

### DIFF
--- a/src/main/grammars/Soy.bnf
+++ b/src/main/grammars/Soy.bnf
@@ -350,7 +350,6 @@ TemplateBlock ::= LocalTemplateBlock | DelegateTemplateBlock {
   implements="com.google.bamboo.soy.elements.TemplateBlockElement"
   stubClass = "com.google.bamboo.soy.stubs.TemplateBlockStub"
   elementTypeFactory = "com.google.bamboo.soy.stubs.StubFactory.getType"
-  hooks=[leftBinder="LEADING_COMMENTS_BINDER"]
 }
 
 private LocalTemplateBlock ::= <<AbstractTemplateBlock TEMPLATE>>
@@ -365,7 +364,7 @@ private meta AbstractTemplateBlock ::=
 }
 
 meta BeginTemplate ::= <<BracedTag <<BeginTemplateBody<<p>>>>>> {
-  hooks=[leftBinder="LEADING_COMMENTS_BINDER" rightBinder="TRAILING_COMMENTS_BINDER"]
+  hooks = [wsBinders = "LEADING_COMMENTS_BINDER, TRAILING_COMMENTS_BINDER"]
 }
 
 private meta BeginTemplateBody ::= <<p>> (TemplateDefinitionIdentifier [AttributeList] | AttributeList) {
@@ -380,7 +379,7 @@ AtParamSingle ::= <<BracedTag AtParamBody>> {
   mixin = "com.google.bamboo.soy.elements.impl.AtParamMixin"
   stubClass = "com.google.bamboo.soy.stubs.AtParamStub"
   elementTypeFactory = "com.google.bamboo.soy.stubs.StubFactory.getType"
-  hooks=[leftBinder="LEADING_COMMENTS_BINDER" rightBinder="TRAILING_COMMENTS_BINDER"]
+  hooks = [wsBinders = "LEADING_COMMENTS_BINDER, TRAILING_COMMENTS_BINDER"]
 }
 
 DocComment ::= DOC_COMMENT_BLOCK
@@ -393,7 +392,7 @@ private AtParamBody ::= (AT_PARAM | AT_PARAM_OPT) ParamDefinitionIdentifier COLO
 AtInjectSingle ::= <<BracedTag AtInjectBody>> {
   implements = "com.google.bamboo.soy.elements.AtInjectElement"
   mixin = "com.google.bamboo.soy.elements.impl.AtInjectMixin"
-  hooks=[leftBinder="LEADING_COMMENTS_BINDER" rightBinder="TRAILING_COMMENTS_BINDER"]
+  hooks = [wsBinders = "LEADING_COMMENTS_BINDER, TRAILING_COMMENTS_BINDER"]
 }
 
 private AtInjectBody ::= (AT_INJECT | AT_INJECT_OPT) ParamDefinitionIdentifier COLON TypeExpression {
@@ -421,7 +420,7 @@ external endOfStatementBlock ::= parseEndOfStatementBlock
 meta StatementList ::= (Statement | !(<<p>> | endOfStatementBlock) CatchallBraces)* {
   recoverWhile = "!(<<p>> | endOfStatementBlock)"
   implements = "com.google.bamboo.soy.elements.StatementListElement"
-  hooks=[leftBinder="GREEDY_LEFT_BINDER" rightBinder="GREEDY_RIGHT_BINDER"]
+  hooks = [wsBinders = "GREEDY_LEFT_BINDER, GREEDY_RIGHT_BINDER"]
 }
 
 // ! It is very important to have the following structure
@@ -550,11 +549,10 @@ private BeginForeachTagBody ::= FOREACH VariableDefinitionIdentifier IN Expr {
 
 LetCompoundStatement ::= BeginLet <<StatementList !()>> <<EndTag LET>> {
   pin = 1
-  hooks=[leftBinder="LEADING_COMMENTS_BINDER"]
 }
 
 BeginLet ::= <<BracedTag BeginLetTagBody>> {
-  hooks=[leftBinder="LEADING_COMMENTS_BINDER" rightBinder="TRAILING_COMMENTS_BINDER"]
+  hooks=[wsBinders="LEADING_COMMENTS_BINDER, TRAILING_COMMENTS_BINDER"]
 }
 
 private BeginLetTagBody ::= LET VariableDefinitionIdentifier [AttributeKeyValuePair] {
@@ -711,7 +709,7 @@ private CssStatementTagBody ::= CSS CssIdentifier
 // Let statement
 
 LetSingleStatement ::= <<BracedTag LetSingleTagBody>> {
-  hooks=[leftBinder="LEADING_COMMENTS_BINDER" rightBinder="TRAILING_COMMENTS_BINDER"]
+  hooks = [wsBinders = "LEADING_COMMENTS_BINDER, TRAILING_COMMENTS_BINDER"]
 }
 
 private LetSingleTagBody ::= LET VariableDefinitionIdentifier COLON Expr {

--- a/src/main/grammars/Soy.bnf
+++ b/src/main/grammars/Soy.bnf
@@ -363,7 +363,9 @@ private meta AbstractTemplateBlock ::=
   pin = 1
 }
 
-meta BeginTemplate ::= <<BracedTag <<BeginTemplateBody<<p>>>>>>
+meta BeginTemplate ::= <<BracedTag <<BeginTemplateBody<<p>>>>>> {
+  hooks=[leftBinder="LEADING_COMMENTS_BINDER" rightBinder="TRAILING_COMMENTS_BINDER"]
+}
 
 private meta BeginTemplateBody ::= <<p>> (TemplateDefinitionIdentifier [AttributeList] | AttributeList) {
   pin = 1
@@ -377,6 +379,7 @@ AtParamSingle ::= <<BracedTag AtParamBody>> {
   mixin = "com.google.bamboo.soy.elements.impl.AtParamMixin"
   stubClass = "com.google.bamboo.soy.stubs.AtParamStub"
   elementTypeFactory = "com.google.bamboo.soy.stubs.StubFactory.getType"
+  hooks=[leftBinder="LEADING_COMMENTS_BINDER" rightBinder="TRAILING_COMMENTS_BINDER"]
 }
 
 DocComment ::= DOC_COMMENT_BLOCK
@@ -389,6 +392,7 @@ private AtParamBody ::= (AT_PARAM | AT_PARAM_OPT) ParamDefinitionIdentifier COLO
 AtInjectSingle ::= <<BracedTag AtInjectBody>> {
   implements = "com.google.bamboo.soy.elements.AtInjectElement"
   mixin = "com.google.bamboo.soy.elements.impl.AtInjectMixin"
+  hooks=[leftBinder="LEADING_COMMENTS_BINDER" rightBinder="TRAILING_COMMENTS_BINDER"]
 }
 
 private AtInjectBody ::= (AT_INJECT | AT_INJECT_OPT) ParamDefinitionIdentifier COLON TypeExpression {
@@ -547,7 +551,9 @@ LetCompoundStatement ::= BeginLet <<StatementList !()>> <<EndTag LET>> {
   pin = 1
 }
 
-BeginLet ::= <<BracedTag BeginLetTagBody>>
+BeginLet ::= <<BracedTag BeginLetTagBody>> {
+  hooks=[leftBinder="LEADING_COMMENTS_BINDER" rightBinder="TRAILING_COMMENTS_BINDER"]
+}
 
 private BeginLetTagBody ::= LET VariableDefinitionIdentifier [AttributeKeyValuePair] {
   pin = 1
@@ -702,7 +708,9 @@ private CssStatementTagBody ::= CSS CssIdentifier
 
 // Let statement
 
-LetSingleStatement ::= <<BracedTag LetSingleTagBody>>
+LetSingleStatement ::= <<BracedTag LetSingleTagBody>> {
+  hooks=[leftBinder="LEADING_COMMENTS_BINDER" rightBinder="TRAILING_COMMENTS_BINDER"]
+}
 
 private LetSingleTagBody ::= LET VariableDefinitionIdentifier COLON Expr {
   pin = 3

--- a/src/main/grammars/Soy.bnf
+++ b/src/main/grammars/Soy.bnf
@@ -350,6 +350,7 @@ TemplateBlock ::= LocalTemplateBlock | DelegateTemplateBlock {
   implements="com.google.bamboo.soy.elements.TemplateBlockElement"
   stubClass = "com.google.bamboo.soy.stubs.TemplateBlockStub"
   elementTypeFactory = "com.google.bamboo.soy.stubs.StubFactory.getType"
+  hooks=[leftBinder="LEADING_COMMENTS_BINDER"]
 }
 
 private LocalTemplateBlock ::= <<AbstractTemplateBlock TEMPLATE>>
@@ -549,6 +550,7 @@ private BeginForeachTagBody ::= FOREACH VariableDefinitionIdentifier IN Expr {
 
 LetCompoundStatement ::= BeginLet <<StatementList !()>> <<EndTag LET>> {
   pin = 1
+  hooks=[leftBinder="LEADING_COMMENTS_BINDER"]
 }
 
 BeginLet ::= <<BracedTag BeginLetTagBody>> {

--- a/src/main/java/com/google/bamboo/soy/elements/CallStatementElement.java
+++ b/src/main/java/com/google/bamboo/soy/elements/CallStatementElement.java
@@ -15,6 +15,7 @@
 package com.google.bamboo.soy.elements;
 
 import com.google.bamboo.soy.parser.SoyBeginCall;
+import com.google.bamboo.soy.parser.SoyEndTag;
 import com.google.bamboo.soy.parser.SoyParamListElement;
 import com.google.bamboo.soy.parser.SoyTypes;
 import java.util.List;
@@ -42,9 +43,9 @@ public interface CallStatementElement extends TagBlockElement, StatementElement 
       return null;
     }
   }
-/*
+
   @Override
   default boolean isIncomplete() {
-    return !getBeginParamTag().isSelfClosed() && !(getLastChild() instanceof SoyEndParamTag);
-  }*/
+    return !getBeginCall().isSelfClosed() && !(getLastChild() instanceof SoyEndTag);
+  }
 }

--- a/src/main/java/com/google/bamboo/soy/elements/TagBlockElement.java
+++ b/src/main/java/com/google/bamboo/soy/elements/TagBlockElement.java
@@ -23,7 +23,7 @@ public interface TagBlockElement extends PsiElement {
 
   @NotNull
   default TagElement getOpeningTag() {
-    return (TagElement) getFirstChild();
+    return (TagElement) WhitespaceUtils.getFirstMeaningChild(this);
   }
 
   @NotNull
@@ -37,7 +37,7 @@ public interface TagBlockElement extends PsiElement {
   }
 
   default boolean isIncomplete() {
-    PsiElement lastChild = getLastChild();
+    PsiElement lastChild = WhitespaceUtils.getLastMeaningChild(this);
     return !(lastChild instanceof SoyEndTag);
   }
 }

--- a/src/main/java/com/google/bamboo/soy/elements/TagElement.java
+++ b/src/main/java/com/google/bamboo/soy/elements/TagElement.java
@@ -15,6 +15,7 @@
 package com.google.bamboo.soy.elements;
 
 import com.google.bamboo.soy.lexer.SoyTokenTypes;
+import com.intellij.psi.PsiComment;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.tree.IElementType;
@@ -26,7 +27,7 @@ public interface TagElement extends PsiElement {
 
   @NotNull
   default PsiElement getTagNameToken() {
-    return PsiTreeUtil.skipSiblingsForward(getFirstChild(), PsiWhiteSpace.class);
+    return WhitespaceUtils.getNextMeaningSibling(getOpeningBrace());
   }
 
   @NotNull
@@ -40,13 +41,18 @@ public interface TagElement extends PsiElement {
   }
 
   @NotNull
+  default PsiElement getOpeningBrace() {
+    return WhitespaceUtils.getFirstMeaningChild(this);
+  }
+
+  @NotNull
   default IElementType getOpeningBraceType() {
-    return getFirstChild().getNode().getElementType();
+    return getOpeningBrace().getNode().getElementType();
   }
 
   @Nullable
   default IElementType getClosingBraceType() {
-    IElementType type = getLastChild().getNode().getElementType();
+    IElementType type = WhitespaceUtils.getLastMeaningChild(this).getNode().getElementType();
     return SoyTokenTypes.RIGHT_BRACES.contains(type) ? type : null;
   }
 

--- a/src/main/java/com/google/bamboo/soy/elements/WhitespaceUtils.java
+++ b/src/main/java/com/google/bamboo/soy/elements/WhitespaceUtils.java
@@ -1,0 +1,36 @@
+package com.google.bamboo.soy.elements;
+
+import com.intellij.psi.PsiComment;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiWhiteSpace;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class WhitespaceUtils {
+  @Nullable
+  public static PsiElement getFirstMeaningChild(PsiElement element) {
+    PsiElement first = element.getFirstChild();
+    return first instanceof PsiWhiteSpace || first instanceof PsiComment
+        ? getNextMeaningSibling(first)
+        : first;
+  }
+
+  @Nullable
+  public static PsiElement getLastMeaningChild(PsiElement element) {
+    PsiElement last = element.getLastChild();
+    return last instanceof PsiWhiteSpace || last instanceof PsiComment
+        ? getPrevMeaningSibling(last)
+        : last;
+  }
+
+  @Nullable
+  public static PsiElement getNextMeaningSibling(PsiElement element) {
+    return PsiTreeUtil.skipSiblingsForward(element, PsiWhiteSpace.class, PsiComment.class);
+  }
+
+  @Nullable
+  public static PsiElement getPrevMeaningSibling(PsiElement element) {
+    return PsiTreeUtil.skipSiblingsBackward(element, PsiWhiteSpace.class, PsiComment.class);
+  }
+}

--- a/src/main/java/com/google/bamboo/soy/elements/WhitespaceUtils.java
+++ b/src/main/java/com/google/bamboo/soy/elements/WhitespaceUtils.java
@@ -1,13 +1,27 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.bamboo.soy.elements;
 
 import com.intellij.psi.PsiComment;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.util.PsiTreeUtil;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class WhitespaceUtils {
+
   @Nullable
   public static PsiElement getFirstMeaningChild(PsiElement element) {
     PsiElement first = element.getFirstChild();

--- a/src/main/java/com/google/bamboo/soy/format/blocks/SoyBlock.java
+++ b/src/main/java/com/google/bamboo/soy/format/blocks/SoyBlock.java
@@ -73,19 +73,7 @@ public class SoyBlock extends TemplateLanguageBlock {
     return element instanceof ParamElement
         || element instanceof SoyAtParamSingle
         || element instanceof SoyAtInjectSingle
-        || element instanceof SoyChoiceClause
-        || isAtParamOrInjectDoc(element);
-  }
-
-  private static boolean isAtParamOrInjectDoc(PsiElement element) {
-    if (!(element instanceof PsiComment)) {
-      return false;
-    }
-    PsiElement sibling = element.getNextSibling();
-    while (sibling instanceof PsiWhiteSpace) {
-      sibling = sibling.getNextSibling();
-    }
-    return sibling instanceof SoyAtParamSingle || sibling instanceof SoyAtInjectSingle;
+        || element instanceof SoyChoiceClause;
   }
 
   private static <T> T findLastDescendantOfType(PsiElement el, Class<T> clazz) {

--- a/src/main/java/com/google/bamboo/soy/format/blocks/SoyBlock.java
+++ b/src/main/java/com/google/bamboo/soy/format/blocks/SoyBlock.java
@@ -18,6 +18,7 @@ import com.google.bamboo.soy.elements.ParamElement;
 import com.google.bamboo.soy.elements.StatementElement;
 import com.google.bamboo.soy.elements.TagBlockElement;
 import com.google.bamboo.soy.elements.TagElement;
+import com.google.bamboo.soy.elements.WhitespaceUtils;
 import com.google.bamboo.soy.parser.SoyAtInjectSingle;
 import com.google.bamboo.soy.parser.SoyAtParamSingle;
 import com.google.bamboo.soy.parser.SoyChoiceClause;
@@ -299,6 +300,7 @@ public class SoyBlock extends TemplateLanguageBlock {
   }
 
   private boolean isDirectTagChild() {
-    return myNode.getPsi().getParent() instanceof TagElement;
+    return myNode.getPsi().getParent() instanceof TagElement
+        && WhitespaceUtils.getPrevMeaningSibling(myNode.getPsi()) != null;
   }
 }

--- a/src/main/java/com/google/bamboo/soy/insight/annotators/IncompleteBlockAnnotator.java
+++ b/src/main/java/com/google/bamboo/soy/insight/annotators/IncompleteBlockAnnotator.java
@@ -1,0 +1,35 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.bamboo.soy.insight.annotators;
+
+import com.google.bamboo.soy.elements.TagBlockElement;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+public class IncompleteBlockAnnotator implements Annotator {
+
+  @Override
+  public void annotate(@NotNull PsiElement psiElement, @NotNull AnnotationHolder annotationHolder) {
+    if (psiElement instanceof TagBlockElement) {
+      TagBlockElement block = (TagBlockElement) psiElement;
+      if (block.isIncomplete()) {
+        annotationHolder.createErrorAnnotation(block.getOpeningTag(),
+            "{" + block.getTagName() + "} is not closed.");
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/bamboo/soy/insight/completion/SoyCompletionContributor.java
+++ b/src/main/java/com/google/bamboo/soy/insight/completion/SoyCompletionContributor.java
@@ -17,6 +17,7 @@ package com.google.bamboo.soy.insight.completion;
 import static com.intellij.patterns.PlatformPatterns.psiElement;
 
 import com.google.bamboo.soy.elements.CallStatementElement;
+import com.google.bamboo.soy.elements.WhitespaceUtils;
 import com.google.bamboo.soy.lang.ParamUtils;
 import com.google.bamboo.soy.lang.Scope;
 import com.google.bamboo.soy.lang.TemplateNameUtils;
@@ -52,10 +53,10 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.intellij.util.Function;
 import com.intellij.util.ProcessingContext;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
@@ -221,8 +222,8 @@ public class SoyCompletionContributor extends CompletionContributor {
               ProcessingContext processingContext,
               @NotNull CompletionResultSet completionResultSet) {
             if (
-            PsiTreeUtil.getParentOfType(
-                completionParameters.getPosition(), CallStatementElement.class).isDelegate()) {
+                PsiTreeUtil.getParentOfType(
+                    completionParameters.getPosition(), CallStatementElement.class).isDelegate()) {
               return;
             }
 
@@ -338,7 +339,8 @@ public class SoyCompletionContributor extends CompletionContributor {
             PsiElement position = completionParameters.getPosition();
             CallStatementElement callStatement =
                 (CallStatementElement)
-                    PsiTreeUtil.findFirstParent(position, elt -> elt instanceof CallStatementElement);
+                    PsiTreeUtil
+                        .findFirstParent(position, elt -> elt instanceof CallStatementElement);
 
             if (callStatement == null) {
               return;
@@ -407,16 +409,13 @@ public class SoyCompletionContributor extends CompletionContributor {
    * Whether the given element is directly preceded by an element matching the predicate (ignoring
    * whitespaces).
    */
-  private boolean isPrecededBy(PsiElement startElement, Function<PsiElement, Boolean> predicate) {
-    PsiElement prevSibling = startElement.getPrevSibling();
-    while (prevSibling != null) {
-      if (!(prevSibling instanceof PsiWhiteSpace)) {
-        return predicate.fun(prevSibling);
+  private boolean isPrecededBy(PsiElement startElement, Predicate<PsiElement> predicate) {
+    for (PsiElement element = WhitespaceUtils.getPrevMeaningSibling(startElement); element != null;
+        element = WhitespaceUtils.getPrevMeaningSibling(element)) {
+      if (predicate.test(element)) {
+        return true;
       }
-
-      prevSibling = prevSibling.getPrevSibling();
     }
-
     return false;
   }
 }

--- a/src/main/java/com/google/bamboo/soy/insight/completion/SoyCompletionContributor.java
+++ b/src/main/java/com/google/bamboo/soy/insight/completion/SoyCompletionContributor.java
@@ -287,7 +287,7 @@ public class SoyCompletionContributor extends CompletionContributor {
   private void extendWithIdentifierFragmentsForAlias() {
     extend(
         CompletionType.BASIC,
-        psiElement().andOr(psiElement().inside(SoyAliasBlock.class)),
+        psiElement().inside(SoyAliasBlock.class),
         new CompletionProvider<CompletionParameters>() {
           @Override
           protected void addCompletions(

--- a/src/main/java/com/google/bamboo/soy/insight/completion/SoyCompletionContributor.java
+++ b/src/main/java/com/google/bamboo/soy/insight/completion/SoyCompletionContributor.java
@@ -220,6 +220,12 @@ public class SoyCompletionContributor extends CompletionContributor {
               @NotNull CompletionParameters completionParameters,
               ProcessingContext processingContext,
               @NotNull CompletionResultSet completionResultSet) {
+            if (
+            PsiTreeUtil.getParentOfType(
+                completionParameters.getPosition(), CallStatementElement.class).isDelegate()) {
+              return;
+            }
+
             completionResultSet.addAllElements(
                 TemplateNameUtils.findLocalTemplateNames(completionParameters.getPosition())
                     .stream()

--- a/src/main/java/com/google/bamboo/soy/parser/SoyParserUtil.java
+++ b/src/main/java/com/google/bamboo/soy/parser/SoyParserUtil.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import com.intellij.lang.PsiBuilder;
 import com.intellij.lang.PsiBuilder.Marker;
 import com.intellij.lang.WhitespacesAndCommentsBinder;
+import com.intellij.lang.WhitespacesAndCommentsBinder.RecursiveBinder;
 import com.intellij.lang.parser.GeneratedParserUtilBase;
 import com.intellij.psi.tree.IElementType;
 import java.util.List;
@@ -47,7 +48,7 @@ public class SoyParserUtil extends GeneratedParserUtilBase {
    * Binds the last leading doc comment either on the same or previous line.
    */
   public static WhitespacesAndCommentsBinder LEADING_COMMENTS_BINDER =
-      new WhitespacesAndCommentsBinder() {
+      new WhitespacesAndCommentsBinder.RecursiveBinder() {
         @Override
         public int getEdgePosition(List<IElementType> tokens, boolean atStreamEdge,
             TokenTextGetter getter) {
@@ -69,7 +70,7 @@ public class SoyParserUtil extends GeneratedParserUtilBase {
    * Binds the trailing doc comments on the same line
    */
   public static WhitespacesAndCommentsBinder TRAILING_COMMENTS_BINDER =
-      new WhitespacesAndCommentsBinder() {
+      new WhitespacesAndCommentsBinder.RecursiveBinder() {
         @Override
         public int getEdgePosition(List<IElementType> tokens, boolean atStreamEdge,
             TokenTextGetter getter) {

--- a/src/main/java/com/google/bamboo/soy/parser/SoyParserUtil.java
+++ b/src/main/java/com/google/bamboo/soy/parser/SoyParserUtil.java
@@ -5,6 +5,7 @@ import static com.google.bamboo.soy.parser.SoyTypes.DELCALL;
 import static com.google.bamboo.soy.parser.SoyTypes.DELTEMPLATE;
 import static com.google.bamboo.soy.parser.SoyTypes.DEL_CALL_STATEMENT;
 import static com.google.bamboo.soy.parser.SoyTypes.DIRECT_CALL_STATEMENT;
+import static com.google.bamboo.soy.parser.SoyTypes.DOC_COMMENT_BLOCK;
 import static com.google.bamboo.soy.parser.SoyTypes.FOR;
 import static com.google.bamboo.soy.parser.SoyTypes.FOREACH;
 import static com.google.bamboo.soy.parser.SoyTypes.FOREACH_STATEMENT;
@@ -31,11 +32,59 @@ import static com.google.bamboo.soy.parser.SoyTypes.TEMPLATE_BLOCK;
 import com.google.common.collect.ImmutableMap;
 import com.intellij.lang.PsiBuilder;
 import com.intellij.lang.PsiBuilder.Marker;
+import com.intellij.lang.WhitespacesAndCommentsBinder;
 import com.intellij.lang.parser.GeneratedParserUtilBase;
 import com.intellij.psi.tree.IElementType;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SoyParserUtil extends GeneratedParserUtilBase {
 
+  private static final Pattern NEWLINE_PATTERN = Pattern.compile("\r\n|\r|\n");
+
+  /**
+   * Binds the last leading doc comment either on the same or previous line.
+   */
+  public static WhitespacesAndCommentsBinder LEADING_COMMENTS_BINDER =
+      new WhitespacesAndCommentsBinder() {
+        @Override
+        public int getEdgePosition(List<IElementType> tokens, boolean atStreamEdge,
+            TokenTextGetter getter) {
+          int newLinesFound = 0;
+          for (int i = tokens.size() - 1; i > 0; i--) {
+            if (tokens.get(i) == DOC_COMMENT_BLOCK) {
+              return i;
+            }
+            newLinesFound += countNewlines(getter.get(i));
+            if (newLinesFound > 1) {
+              break;
+            }
+          }
+          return tokens.size();
+        }
+      };
+
+  /**
+   * Binds the trailing doc comments on the same line
+   */
+  public static WhitespacesAndCommentsBinder TRAILING_COMMENTS_BINDER =
+      new WhitespacesAndCommentsBinder() {
+        @Override
+        public int getEdgePosition(List<IElementType> tokens, boolean atStreamEdge,
+            TokenTextGetter getter) {
+          int edgePosition = 0;
+          for (int i = 0; i < tokens.size(); i++) {
+            if (tokens.get(i) == DOC_COMMENT_BLOCK) {
+              edgePosition = i + 1;
+            }
+            if (countNewlines(getter.get(i)) > 0) {
+              break;
+            }
+          }
+          return edgePosition;
+        }
+      };
   private static ImmutableMap<IElementType, IElementType> closingTokenToBlock =
       ImmutableMap.<IElementType, IElementType>builder()
           .put(CALL, DIRECT_CALL_STATEMENT)
@@ -53,7 +102,18 @@ public class SoyParserUtil extends GeneratedParserUtilBase {
           .put(TEMPLATE, TEMPLATE_BLOCK)
           .build();
 
-  /* Matches a closing tag iff there is frame in the stack which it may close. */
+  private static int countNewlines(CharSequence s) {
+    int n = 0;
+    Matcher matcher = NEWLINE_PATTERN.matcher(s);
+    while (matcher.find()) {
+      n++;
+    }
+    return n;
+  }
+
+  /**
+   * Matches a closing tag iff there is frame in the stack which it may close.
+   */
   public static boolean parseEndOfStatementBlock(PsiBuilder builder, int level) {
     if (!nextTokenIs(builder, "", LBRACE_SLASH, LBRACE_LBRACE_SLASH)) {
       return false;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -209,6 +209,9 @@
       implementationClass="com.google.bamboo.soy.insight.annotators.DeltemplateIdentifierAnnotator"/>
     <annotator
       language="ClosureTemplate"
+      implementationClass="com.google.bamboo.soy.insight.annotators.IncompleteBlockAnnotator"/>
+    <annotator
+      language="ClosureTemplate"
       implementationClass="com.google.bamboo.soy.insight.annotators.UnexpectedStatementsAnnotator"/>
     <annotator
       language="ClosureTemplate"

--- a/src/test/java/com/google/bamboo/soy/insight/SoyCompletionTest.java
+++ b/src/test/java/com/google/bamboo/soy/insight/SoyCompletionTest.java
@@ -14,15 +14,16 @@
 
 package com.google.bamboo.soy.insight;
 
+import com.google.bamboo.soy.SoyCodeInsightFixtureTestCase;
 import com.google.bamboo.soy.file.SoyFileType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.bamboo.soy.SoyCodeInsightFixtureTestCase;
 import com.intellij.codeInsight.completion.CompletionType;
 import java.util.List;
 import java.util.Set;
 
 public class SoyCompletionTest extends SoyCodeInsightFixtureTestCase {
+
   @Override
   protected String getBasePath() {
     return "/insight";
@@ -52,6 +53,17 @@ public class SoyCompletionTest extends SoyCodeInsightFixtureTestCase {
   public void testTemplateLookup() throws Throwable {
     doTest("{template}{call o<caret>", "{template}{call outer");
     doTest("{template}{call outer.<caret>", ImmutableSet.of("outer.space", "outer.spaceship"));
+    doTest(
+        "{template}{call outer.space.m<caret>",
+        ImmutableSet.of("outer.space.mars", "outer.space.moon"));
+    doTest("{template}{delcall d<caret>", "{template}{delcall delegate");
+  }
+
+  public void testLocalTemplateLookup() throws Throwable {
+    doTest("{template .local}{/template}{template}{call .<caret>",
+        "{template .local}{/template}{template}{call .local");
+    doTest("{deltemplate local.template}{/deltemplate}{template}{delcall l<caret>",
+        ImmutableSet.of());
     doTest(
         "{template}{call outer.space.m<caret>",
         ImmutableSet.of("outer.space.mars", "outer.space.moon"));

--- a/src/test/java/com/google/bamboo/soy/insight/SoyDocumentationProviderTest.java
+++ b/src/test/java/com/google/bamboo/soy/insight/SoyDocumentationProviderTest.java
@@ -15,15 +15,8 @@
 package com.google.bamboo.soy.insight;
 
 import com.google.bamboo.soy.SoyCodeInsightFixtureTestCase;
-import com.google.bamboo.soy.file.SoyFileType;
 import com.google.bamboo.soy.insight.documentation.SoyDocumentationProvider;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiReference;
-import java.util.List;
-import java.util.Set;
 
 public class SoyDocumentationProviderTest extends SoyCodeInsightFixtureTestCase {
 

--- a/src/test/java/com/google/bamboo/soy/insight/SoyDocumentationProviderTest.java
+++ b/src/test/java/com/google/bamboo/soy/insight/SoyDocumentationProviderTest.java
@@ -1,0 +1,72 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.bamboo.soy.insight;
+
+import com.google.bamboo.soy.SoyCodeInsightFixtureTestCase;
+import com.google.bamboo.soy.file.SoyFileType;
+import com.google.bamboo.soy.insight.documentation.SoyDocumentationProvider;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import java.util.List;
+import java.util.Set;
+
+public class SoyDocumentationProviderTest extends SoyCodeInsightFixtureTestCase {
+
+  @Override
+  protected String getBasePath() {
+    return "/insight";
+  }
+
+  private void doTest(String expectedQuickNavigateInfo) {
+    String filename = getTestName(false) + ".soy";
+    myFixture.configureByFile(filename);
+    PsiElement element = myFixture.getElementAtCaret();
+    String info = (new SoyDocumentationProvider()).getQuickNavigateInfo(element, null);
+    assertEquals(expectedQuickNavigateInfo, info);
+  }
+
+  public void testAtInjectReference() {
+    doTest("Defined at AtInjectReference.soy:5\n"
+        + "Leading doc");
+  }
+
+  public void testAtParamReference() {
+    doTest("Defined at AtParamReference.soy:5\n"
+        + "Leading doc");
+  }
+
+  public void testLetDefinitionReference() {
+    doTest("Defined at LetDefinitionReference.soy:5\n"
+        + "Leading doc");
+  }
+
+  public void testAtInjectReferenceTrailingDoc() {
+    doTest("Defined at AtInjectReferenceTrailingDoc.soy:4\n"
+        + "Same-line doc");
+  }
+
+  public void testAtParamReferenceTrailingDoc() {
+    doTest("Defined at AtParamReferenceTrailingDoc.soy:4\n"
+        + "Same-line doc");
+  }
+
+  public void testLetDefinitionReferenceTrailingDoc() {
+    doTest("Defined at LetDefinitionReferenceTrailingDoc.soy:4\n"
+        + "Same-line doc");
+  }
+}

--- a/src/test/java/com/google/bamboo/soy/insight/annotators/IncompleteBlockAnnotatorTest.java
+++ b/src/test/java/com/google/bamboo/soy/insight/annotators/IncompleteBlockAnnotatorTest.java
@@ -1,0 +1,17 @@
+package com.google.bamboo.soy.insight.annotators;
+
+import com.google.bamboo.soy.SoyCodeInsightFixtureTestCase;
+import com.google.bamboo.soy.elements.TagElement;
+
+public class IncompleteBlockAnnotatorTest extends SoyCodeInsightFixtureTestCase {
+
+  @Override
+  protected String getBasePath() {
+    return "/insight/annotators";
+  }
+
+  public void testAnnotator() {
+    myFixture.configureByFile("IncompleteBlock.soy");
+    myFixture.checkHighlighting(false, false, true, true);
+  }
+}

--- a/src/test/resources/insight/AtInjectReferenceTrailingDoc.soy
+++ b/src/test/resources/insight/AtInjectReferenceTrailingDoc.soy
@@ -1,7 +1,6 @@
 {namespace at.param.reference.test.file}
 
 {template .moon}
-  /** Leading doc */
   {@inject planet : string} /** Same-line doc */
 
   Planet: {$pla<caret>net}

--- a/src/test/resources/insight/AtParamReference.soy
+++ b/src/test/resources/insight/AtParamReference.soy
@@ -1,7 +1,8 @@
 {namespace at.param.reference.test.file}
 
 {template .moon}
-  {@param planet : string}
+  /** Leading doc */
+  {@param planet : string} /** Same-line doc */
 
   Planet: {$pla<caret>net}
 {/template}

--- a/src/test/resources/insight/AtParamReferenceTrailingDoc.soy
+++ b/src/test/resources/insight/AtParamReferenceTrailingDoc.soy
@@ -1,8 +1,7 @@
 {namespace at.param.reference.test.file}
 
 {template .moon}
-  /** Leading doc */
-  {@inject planet : string} /** Same-line doc */
+  {@param planet : string} /** Same-line doc */
 
   Planet: {$pla<caret>net}
 {/template}

--- a/src/test/resources/insight/CompletionSource.soy
+++ b/src/test/resources/insight/CompletionSource.soy
@@ -15,3 +15,6 @@
 {template .earth}{/template}
 {template .mars}{/template}
 {template .moose_ visibility="private"}{/template}
+
+{deltemplate delegate.template}
+{/deltemplate}

--- a/src/test/resources/insight/LetDefinitionReference.soy
+++ b/src/test/resources/insight/LetDefinitionReference.soy
@@ -1,7 +1,8 @@
 {namespace at.param.reference.test.file}
 
 {template .moon}
-  {let $planet : 'Earth' /}
+  /** Leading doc */
+  {let $planet : 'Earth' /} /** Same-line doc */
 
   Planet: {$pla<caret>net}
 {/template}

--- a/src/test/resources/insight/LetDefinitionReferenceTrailingDoc.soy
+++ b/src/test/resources/insight/LetDefinitionReferenceTrailingDoc.soy
@@ -1,8 +1,9 @@
 {namespace at.param.reference.test.file}
 
 {template .moon}
-  /** Leading doc */
-  {@inject planet : string} /** Same-line doc */
+  {let $planet} /** Same-line doc */
+    Earth
+  {/let}
 
   Planet: {$pla<caret>net}
 {/template}

--- a/src/test/resources/insight/annotators/IncompleteBlock.soy
+++ b/src/test/resources/insight/annotators/IncompleteBlock.soy
@@ -1,0 +1,11 @@
+{namespace space}
+
+{template .foo}
+  {call .foo}
+    <error descr="{param} is not closed.">{param a: 1}</error>
+
+{/template}
+
+{template .foo}
+    <error descr="{call} is not closed."{call .foo}</error>
+{/template}


### PR DESCRIPTION
* Not suggesting local templates for delcalls (accidentally broken by merging *BeginCalls).
* Annotating unclosed blocks (was partially working before by chance).
* Binding doc comments to the elements they are referring to.
* Tests for doc comments.